### PR TITLE
Fix download of OVAL definition for RHEL 8

### DIFF
--- a/scripts/openscap.cmd
+++ b/scripts/openscap.cmd
@@ -1,7 +1,7 @@
 @echo off
 echo =====Start download for openscap=======
 
-curl --ssl-no-revoke https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2 -o %OPENSCAP_DIR%\rhel-8.oval.xml.bz2
+curl --ssl-no-revoke -L https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2 -o %OPENSCAP_DIR%\rhel-8.oval.xml.bz2
 
 :completed
 echo =====Complete download for openscap=======


### PR DESCRIPTION
## Context

File is incorrectly generated when running the `openscap.cmd` script, i.e. has a size of 0 bytes.

---

## Changelog

- fix: Include flag to follow redirects when downloading OVAL definition for RHEL 8